### PR TITLE
convert teachers scss to bootstrap utility class

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,15 @@
+@import "bootstrap/scss/functions";
+@import "bootstrap/scss/variables";
+
+$theme-colors: map-merge(
+  $theme-colors,
+  (
+    "secondary-green": #026e57,
+    "card-green": #f9fffc,
+    "shadow-grey": #d5d5d5,
+  )
+);
+
 @import "theme";
 @import "bootstrap/scss/bootstrap";
 @import 'autoComplete';

--- a/app/assets/stylesheets/teacher.scss
+++ b/app/assets/stylesheets/teacher.scss
@@ -1,29 +1,3 @@
 .teacher-main-description-container {
-  margin-bottom: 35px;
-  margin-left: auto;
-  margin-right: auto;
   max-width: 768px;
-}
-
-.teacher-fill-container-fluid {
-  background-color: $card-green;
-  padding: 40px 0;
-}
-
-.teacher-container-fluid {
-  padding: 40px 0;
-}
-
-.teacher-center-content {
-  align-items: center;
-}
-
-.teacher-image {
-  border: 2px solid $shadow-grey;
-  max-height: 100%;
-  max-width: 100%;
-}
-
-.teacher-left-text {
-  text-align: left;
 }

--- a/app/views/circuitverse/teachers.html.erb
+++ b/app/views/circuitverse/teachers.html.erb
@@ -2,61 +2,61 @@
 
 <div class="row center-row">
   <div class="col-12">
-    <h1 class="main-heading"><%= t("circuitverse.teachers.main_heading") %></h1>
-    <div class="teacher-main-description-container">
+    <h1 class="mt-5 mb-2 text-secondary-green"><%= t("circuitverse.teachers.main_heading") %></h1>
+    <div class="teacher-main-description-container mx-auto mb-3">
       <p class="main-description"><%= t("circuitverse.teachers.main_description") %></p>
     </div> <br>
     <h2><%= t("circuitverse.teachers.benefits") %></h2>
   </div>
 </div>
-<div class="container-fluid teacher-fill-container-fluid">
+<div class="container-fluid py-5 bg-card-green">
   <div class="container">
-    <div class="row center-row teacher-center-content">
-      <div class="col-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
+    <div class="row center-row">
+      <div class="col-12 col-sm-12 col-md-6 col-lg-6 text-start">
         <h4><%= t("circuitverse.teachers.create_group_heading") %></h4> <br>
         <p><%= t("circuitverse.teachers.create_group_description") %></p>
       </div>
       <div class="col-12 col-sm-12 col-md-6 col-lg-6">
-        <img class="teacher-image" src="img/groups.png" alt="Groups screenshot">
+        <img class="border border-2 border-shadow-grey mh-100 mw-100" src="img/groups.png" alt="Groups screenshot">
       </div>
     </div>
   </div>
 </div>
-<div class="container-fluid teacher-container-fluid">
+<div class="container-fluid py-5">
   <div class="container">
-    <div class="row center-row teacher-center-content">
-      <div class="col-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
+    <div class="row center-row">
+      <div class="col-12 col-sm-12 col-md-6 col-lg-6 text-start">
         <h4><%= t("circuitverse.teachers.post_assignment_heading") %></h4> <br>
         <p><%= t("circuitverse.teachers.post_assignment_description") %></p>
       </div>
       <div class="col-12 col-sm-12 col-md-6 col-lg-6">
-        <img class="teacher-image" src="img/assignment.png" alt="Assignments screenshot">
+        <img class="border border-2 border-shadow-grey mh-100 mw-100" src="img/assignment.png" alt="Assignments screenshot">
       </div>
     </div>
   </div>
 </div>
-<div class="container-fluid teacher-fill-container-fluid">
+<div class="container-fluid py-5 bg-card-green">
   <div class="container">
-    <div class="row center-row teacher-center-content">
-      <div class="col-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
+    <div class="row center-row">
+      <div class="col-12 col-sm-12 col-md-6 col-lg-6 text-start">
         <h4><%= t("circuitverse.teachers.grade_assignment_heading") %></h4> <br>
         <p><%= t("circuitverse.teachers.grade_assignment_description") %></p>
       </div>
       <div class="col-12 col-sm-12 col-md-6 col-lg-6">
-        <img class="teacher-image" src="img/grading.png" alt="Grading screenshot" height="250px">
+        <img class="border border-2 border-shadow-grey mh-100 mw-100" src="img/grading.png" alt="Grading screenshot" height="250px">
       </div>
     </div>
   </div>
 </div>
-<div class="container-fluid teacher-container-fluid">
+<div class="container-fluid py-5">
   <div class="container">
-    <div class="row center-row teacher-center-content">
-      <div class="col-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
+    <div class="row center-row">
+      <div class="col-12 col-sm-12 col-md-6 col-lg-6 text-start">
         <h4><%= t("circuitverse.teachers.use_interactive_circuit_heading") %></h4> <br>
         <p><%= t("circuitverse.teachers.use_interactive_circuit_description") %></p>
       </div>
       <div class="col-12 col-sm-12 col-md-6 col-lg-6">
-        <img class="teacher-image" src="img/embed.png" alt="Embed screenshot" height="350px">
+        <img class="border border-2 border-shadow-grey mh-100 mw-100" src="img/embed.png" alt="Embed screenshot" height="350px">
       </div>
     </div>
   </div>


### PR DESCRIPTION
Goal 3: UI Improvements 

#### Describe the changes you have made in this PR -
Remove Custom CSS with Bootstrap Utility Classes For teachers.scss and teachers.html.erb
Configure 3 Colors for teachers.html.erb in bootstrap utilities using map merge.

### Screenshots of the UI changes (If any) -
Before - 
<img width="1896" alt="Screenshot 2025-04-06 at 8 34 31 PM" src="https://github.com/user-attachments/assets/c0eac02c-50e8-4251-827f-98fb999cedb1" />
After - 
<img width="1896" alt="after" src="https://github.com/user-attachments/assets/e2266a6b-7a06-4c8a-bfd6-427ffce68500" />

<!-- Do not add code diff here -->


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
